### PR TITLE
Fix popping home screen 

### DIFF
--- a/lib/features/bulkblock/presentation/widgets/splash_screen_widget.dart
+++ b/lib/features/bulkblock/presentation/widgets/splash_screen_widget.dart
@@ -19,7 +19,7 @@ class _SplashScreenWidgetState extends State<SplashScreenWidget> {
   void initState() {
     super.initState();
     Timer(const Duration(seconds: 5), () {
-      Navigator.push(context, widget.nextRoute);
+      Navigator.pushReplacement(context, widget.nextRoute);
     });
   }
 


### PR DESCRIPTION
**ISSUE:** Home page was being pushed to top of stack which meant when it was popped by pressing the back button, splash screen would appear. 
**FIX:** now home page is replaced as top of stack so splash screen is no longer re-navigable